### PR TITLE
Fix error message for completely missing sites

### DIFF
--- a/src/method.c
+++ b/src/method.c
@@ -3113,7 +3113,7 @@ static FILE * init(stree_t ** ptr_stree,
     int deleted = msa_remove_missing_sequences(msa_list[i]);
     if (deleted == -1)
       fatal("[ERROR]: Locus %ld contains missing sequences only.\n"
-        "Please remove the locus and restart the analysis.\n");
+        "Please remove the locus and restart the analysis.\n", i);
 
     if (deleted)
     {


### PR DESCRIPTION
`%ld` gives uninitialized random number since locus number is not provided for the format string.

This PR adds the missing argument.